### PR TITLE
feat: Add Question entity, DTOs, repository and gradle dep

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	//충돌유도 B feature/13-question-data-model
 }
 
 tasks.withType<Test> {

--- a/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/domain/Question.java
+++ b/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/domain/Question.java
@@ -1,0 +1,4 @@
+package io.github.fuzzylogicbox.soarrunningseoul.domain;
+
+public class Question {
+}

--- a/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/dto/QuestionRequestDto.java
+++ b/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/dto/QuestionRequestDto.java
@@ -1,0 +1,4 @@
+package io.github.fuzzylogicbox.soarrunningseoul.dto;
+
+public class QuestionRequestDto {
+}

--- a/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/dto/QuestionResponseDto.java
+++ b/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/dto/QuestionResponseDto.java
@@ -1,0 +1,4 @@
+package io.github.fuzzylogicbox.soarrunningseoul.dto;
+
+public class QuestionResponseDto {
+}

--- a/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/repository/QuestionRepository.java
+++ b/src/main/java/io/github/fuzzylogicbox/soarrunningseoul/repository/QuestionRepository.java
@@ -1,0 +1,4 @@
+package io.github.fuzzylogicbox.soarrunningseoul.repository;
+
+public class QuestionRepository {
+}


### PR DESCRIPTION
### Changed
 - 엔티티, 리퀘스트와 리스폰스 dto, 리포지토리 생성
 - build.gradle.kts에 충돌유도 주석 추가
### Issue No.
 - #13 
 - #29 